### PR TITLE
Added client="site" to modules

### DIFF
--- a/admin/helpers/project/manifest.php
+++ b/admin/helpers/project/manifest.php
@@ -141,6 +141,10 @@ class EcrProjectManifest extends JObject
                 {
                     $this->manifest->addAttribute('client', 'administrator');
                 }
+                else
+                {
+                	$this->manifest->addAttribute('client', 'site');
+                }
                 break;
             case 'plugin':
                 $this->manifest->addAttribute('group', $this->project->scope);


### PR DESCRIPTION
Joomla 3.7 requires all site modules to have the `client="site"` attribute in the XML Manifest.